### PR TITLE
WIP - xds/internal:cluster remove Generic resource Decoder and added concrete functions

### DIFF
--- a/internal/xds/balancer/cdsbalancer/cluster_watcher.go
+++ b/internal/xds/balancer/cdsbalancer/cluster_watcher.go
@@ -19,6 +19,7 @@ package cdsbalancer
 import (
 	"context"
 
+	"google.golang.org/grpc/internal/xds/clients/xdsclient"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
 )
 
@@ -32,8 +33,9 @@ type clusterWatcher struct {
 	parent *cdsBalancer
 }
 
-func (cw *clusterWatcher) ResourceChanged(u *xdsresource.ClusterResourceData, onDone func()) {
-	handleUpdate := func(context.Context) { cw.parent.onClusterUpdate(cw.name, u.Resource); onDone() }
+func (cw *clusterWatcher) ResourceChanged(rd xdsclient.ResourceData, onDone func()) {
+	clusterData := rd.(*xdsresource.ClusterResourceData)
+	handleUpdate := func(context.Context) { cw.parent.onClusterUpdate(cw.name, clusterData.Resource); onDone() }
 	cw.parent.serializer.ScheduleOr(handleUpdate, onDone)
 }
 

--- a/internal/xds/xdsclient/clientimpl_test.go
+++ b/internal/xds/xdsclient/clientimpl_test.go
@@ -83,7 +83,7 @@ func (s) TestBuildXDSClientConfig_Success(t *testing.T) {
 					ResourceTypes: map[string]xdsclient.ResourceType{
 						version.V3ListenerURL:    {TypeURL: version.V3ListenerURL, TypeName: xdsresource.ListenerResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewGenericListenerResourceTypeDecoder(c)},
 						version.V3RouteConfigURL: {TypeURL: version.V3RouteConfigURL, TypeName: xdsresource.RouteConfigTypeName, AllResourcesRequiredInSotW: false, Decoder: xdsresource.NewGenericRouteConfigResourceTypeDecoder()},
-						version.V3ClusterURL:     {TypeURL: version.V3ClusterURL, TypeName: xdsresource.ClusterResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewGenericClusterResourceTypeDecoder(c, gServerCfgMap)},
+						version.V3ClusterURL:     {TypeURL: version.V3ClusterURL, TypeName: xdsresource.ClusterResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewClusterResourceTypeDecoder(c, gServerCfgMap)},
 						version.V3EndpointsURL:   {TypeURL: version.V3EndpointsURL, TypeName: xdsresource.EndpointsResourceTypeName, AllResourcesRequiredInSotW: false, Decoder: xdsresource.NewGenericEndpointsResourceTypeDecoder()},
 					},
 					MetricsReporter: &metricsReporter{recorder: stats.NewTestMetricsRecorder(), target: testTargetName},
@@ -121,7 +121,7 @@ func (s) TestBuildXDSClientConfig_Success(t *testing.T) {
 					ResourceTypes: map[string]xdsclient.ResourceType{
 						version.V3ListenerURL:    {TypeURL: version.V3ListenerURL, TypeName: xdsresource.ListenerResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewGenericListenerResourceTypeDecoder(c)},
 						version.V3RouteConfigURL: {TypeURL: version.V3RouteConfigURL, TypeName: xdsresource.RouteConfigTypeName, AllResourcesRequiredInSotW: false, Decoder: xdsresource.NewGenericRouteConfigResourceTypeDecoder()},
-						version.V3ClusterURL:     {TypeURL: version.V3ClusterURL, TypeName: xdsresource.ClusterResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewGenericClusterResourceTypeDecoder(c, gSCfgMap)},
+						version.V3ClusterURL:     {TypeURL: version.V3ClusterURL, TypeName: xdsresource.ClusterResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewClusterResourceTypeDecoder(c, gSCfgMap)},
 						version.V3EndpointsURL:   {TypeURL: version.V3EndpointsURL, TypeName: xdsresource.EndpointsResourceTypeName, AllResourcesRequiredInSotW: false, Decoder: xdsresource.NewGenericEndpointsResourceTypeDecoder()},
 					},
 					MetricsReporter: &metricsReporter{recorder: stats.NewTestMetricsRecorder(), target: testTargetName},
@@ -153,7 +153,7 @@ func (s) TestBuildXDSClientConfig_Success(t *testing.T) {
 					ResourceTypes: map[string]xdsclient.ResourceType{
 						version.V3ListenerURL:    {TypeURL: version.V3ListenerURL, TypeName: xdsresource.ListenerResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewGenericListenerResourceTypeDecoder(c)},
 						version.V3RouteConfigURL: {TypeURL: version.V3RouteConfigURL, TypeName: xdsresource.RouteConfigTypeName, AllResourcesRequiredInSotW: false, Decoder: xdsresource.NewGenericRouteConfigResourceTypeDecoder()},
-						version.V3ClusterURL:     {TypeURL: version.V3ClusterURL, TypeName: xdsresource.ClusterResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewGenericClusterResourceTypeDecoder(c, gServerCfgMap)},
+						version.V3ClusterURL:     {TypeURL: version.V3ClusterURL, TypeName: xdsresource.ClusterResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewClusterResourceTypeDecoder(c, gServerCfgMap)},
 						version.V3EndpointsURL:   {TypeURL: version.V3EndpointsURL, TypeName: xdsresource.EndpointsResourceTypeName, AllResourcesRequiredInSotW: false, Decoder: xdsresource.NewGenericEndpointsResourceTypeDecoder()},
 					},
 					MetricsReporter: &metricsReporter{recorder: stats.NewTestMetricsRecorder(), target: testTargetName},
@@ -185,7 +185,7 @@ func (s) TestBuildXDSClientConfig_Success(t *testing.T) {
 					ResourceTypes: map[string]xdsclient.ResourceType{
 						version.V3ListenerURL:    {TypeURL: version.V3ListenerURL, TypeName: xdsresource.ListenerResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewGenericListenerResourceTypeDecoder(c)},
 						version.V3RouteConfigURL: {TypeURL: version.V3RouteConfigURL, TypeName: xdsresource.RouteConfigTypeName, AllResourcesRequiredInSotW: false, Decoder: xdsresource.NewGenericRouteConfigResourceTypeDecoder()},
-						version.V3ClusterURL:     {TypeURL: version.V3ClusterURL, TypeName: xdsresource.ClusterResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewGenericClusterResourceTypeDecoder(c, gServerCfgMap)},
+						version.V3ClusterURL:     {TypeURL: version.V3ClusterURL, TypeName: xdsresource.ClusterResourceTypeName, AllResourcesRequiredInSotW: true, Decoder: xdsresource.NewClusterResourceTypeDecoder(c, gServerCfgMap)},
 						version.V3EndpointsURL:   {TypeURL: version.V3EndpointsURL, TypeName: xdsresource.EndpointsResourceTypeName, AllResourcesRequiredInSotW: false, Decoder: xdsresource.NewGenericEndpointsResourceTypeDecoder()},
 					},
 					MetricsReporter: &metricsReporter{recorder: stats.NewTestMetricsRecorder(), target: testTargetName},

--- a/internal/xds/xdsclient/resource_types.go
+++ b/internal/xds/xdsclient/resource_types.go
@@ -42,7 +42,7 @@ func supportedResourceTypes(config *bootstrap.Config, gServerCfgMap map[xdsclien
 			TypeURL:                    version.V3ClusterURL,
 			TypeName:                   xdsresource.ClusterResourceTypeName,
 			AllResourcesRequiredInSotW: true,
-			Decoder:                    xdsresource.NewGenericClusterResourceTypeDecoder(config, gServerCfgMap),
+			Decoder:                    xdsresource.NewClusterResourceTypeDecoder(config, gServerCfgMap),
 		},
 		version.V3EndpointsURL: {
 			TypeURL:                    version.V3EndpointsURL,

--- a/internal/xds/xdsclient/tests/authority_test.go
+++ b/internal/xds/xdsclient/tests/authority_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/xds/bootstrap"
+	clientimpl "google.golang.org/grpc/internal/xds/clients/xdsclient"
 	xdstestutils "google.golang.org/grpc/internal/xds/testutils"
 	"google.golang.org/grpc/internal/xds/xdsclient"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
@@ -351,8 +352,9 @@ func newClusterWatcherV2() *clusterWatcherV2 {
 	}
 }
 
-func (cw *clusterWatcherV2) ResourceChanged(update *xdsresource.ClusterResourceData, onDone func()) {
-	cw.updateCh.Send(update.Resource)
+func (cw *clusterWatcherV2) ResourceChanged(rd clientimpl.ResourceData, onDone func()) {
+	clusterData := rd.(*xdsresource.ClusterResourceData)
+	cw.updateCh.Send(clusterUpdateErrTuple{update: clusterData.Resource})
 	onDone()
 }
 

--- a/internal/xds/xdsclient/tests/cds_watchers_test.go
+++ b/internal/xds/xdsclient/tests/cds_watchers_test.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/xds/bootstrap"
+	clientimpl "google.golang.org/grpc/internal/xds/clients/xdsclient"
 	"google.golang.org/grpc/internal/xds/xdsclient"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
 
@@ -44,7 +45,7 @@ import (
 
 type noopClusterWatcher struct{}
 
-func (noopClusterWatcher) ResourceChanged(_ *xdsresource.ClusterResourceData, onDone func()) {
+func (noopClusterWatcher) ResourceChanged(_ clientimpl.ResourceData, onDone func()) {
 	onDone()
 }
 func (noopClusterWatcher) ResourceError(_ error, onDone func()) {
@@ -67,8 +68,9 @@ func newClusterWatcher() *clusterWatcher {
 	return &clusterWatcher{updateCh: testutils.NewChannel()}
 }
 
-func (cw *clusterWatcher) ResourceChanged(update *xdsresource.ClusterResourceData, onDone func()) {
-	cw.updateCh.Send(clusterUpdateErrTuple{update: update.Resource})
+func (cw *clusterWatcher) ResourceChanged(rd clientimpl.ResourceData, onDone func()) {
+	clusterData := rd.(*xdsresource.ClusterResourceData)
+	cw.updateCh.Send(clusterUpdateErrTuple{update: clusterData.Resource})
 	onDone()
 }
 

--- a/internal/xds/xdsclient/xdsresource/resource_type.go
+++ b/internal/xds/xdsclient/xdsresource/resource_type.go
@@ -25,8 +25,6 @@
 package xdsresource
 
 import (
-	"fmt"
-
 	xdsinternal "google.golang.org/grpc/internal/xds"
 	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/internal/xds/clients/xdsclient"
@@ -38,7 +36,7 @@ func init() {
 	xdsinternal.ResourceTypeMapForTesting = make(map[string]any)
 	xdsinternal.ResourceTypeMapForTesting[version.V3ListenerURL] = listenerType
 	xdsinternal.ResourceTypeMapForTesting[version.V3RouteConfigURL] = routeConfigType
-	xdsinternal.ResourceTypeMapForTesting[version.V3ClusterURL] = clusterType
+	xdsinternal.ResourceTypeMapForTesting[version.V3ClusterURL] = ClusterResource
 	xdsinternal.ResourceTypeMapForTesting[version.V3EndpointsURL] = endpointsType
 }
 
@@ -52,7 +50,7 @@ type Producer interface {
 	// xDS responses are are deserialized and validated, as received from the
 	// xDS management server. Upon receipt of a response from the management
 	// server, an appropriate callback on the watcher is invoked.
-	WatchResource(rType Type, resourceName string, watcher ResourceWatcher) (cancel func())
+	WatchResource(rType xdsclient.ResourceType, resourceName string, watcher xdsclient.ResourceWatcher) (cancel func())
 }
 
 // ResourceWatcher is notified of the resource updates and errors that are
@@ -86,7 +84,7 @@ type ResourceWatcher interface {
 
 // Type wraps all resource-type specific functionality. Each supported resource
 // type will provide an implementation of this interface.
-type Type interface {
+type ResourceType interface {
 	// TypeURL is the xDS type URL of this resource type for v3 transport.
 	TypeURL() string
 
@@ -97,7 +95,7 @@ type Type interface {
 	//
 	// TODO: once Type is renamed to ResourceType, rename TypeName to
 	// ResourceTypeName.
-	TypeName() string
+	ResourceTypeName() string
 
 	// AllResourcesRequiredInSotW indicates whether this resource type requires
 	// that all resources be present in every SotW response from the server. If
@@ -111,7 +109,7 @@ type Type interface {
 	// If protobuf deserialization fails or resource validation fails,
 	// returns a non-nil error. Otherwise, returns a fully populated
 	// DecodeResult.
-	Decode(*DecodeOptions, *anypb.Any) (*DecodeResult, error)
+	Decode(*xdsclient.AnyProto, xdsclient.DecodeOptions) (*xdsclient.DecodeResult, error)
 }
 
 // ResourceData contains the configuration data sent by the xDS management
@@ -169,120 +167,4 @@ func (r resourceTypeState) TypeName() string {
 
 func (r resourceTypeState) AllResourcesRequiredInSotW() bool {
 	return r.allResourcesRequiredInSotW
-}
-
-// GenericResourceTypeDecoder wraps an xdsresource.Type and implements
-// xdsclient.Decoder.
-//
-// TODO: #8313 - Delete this once the internal xdsclient usages are updated
-// to use the generic xdsclient.ResourceType interface directly.
-type GenericResourceTypeDecoder struct {
-	ResourceType    Type
-	BootstrapConfig *bootstrap.Config
-	ServerConfigMap map[xdsclient.ServerConfig]*bootstrap.ServerConfig
-}
-
-// Decode deserialize and validate resource bytes of an xDS resource received
-// from the xDS management server.
-func (gd *GenericResourceTypeDecoder) Decode(resource xdsclient.AnyProto, gOpts xdsclient.DecodeOptions) (*xdsclient.DecodeResult, error) {
-	rProto := &anypb.Any{
-		TypeUrl: resource.TypeURL,
-		Value:   resource.Value,
-	}
-	opts := &DecodeOptions{BootstrapConfig: gd.BootstrapConfig}
-	if gOpts.ServerConfig != nil {
-		opts.ServerConfig = gd.ServerConfigMap[*gOpts.ServerConfig]
-	}
-
-	result, err := gd.ResourceType.Decode(opts, rProto)
-	if result == nil {
-		return nil, err
-	}
-	if err != nil {
-		return &xdsclient.DecodeResult{Name: result.Name}, err
-	}
-
-	return &xdsclient.DecodeResult{Name: result.Name, Resource: &genericResourceData{resourceData: result.Resource}}, nil
-}
-
-// genericResourceData embed an xdsresource.ResourceData and implements
-// xdsclient.ResourceData.
-//
-// TODO: #8313 - Delete this once the internal xdsclient usages are updated
-// to use the generic xdsclient.ResourceData interface directly.
-type genericResourceData struct {
-	resourceData ResourceData
-}
-
-// Equal returns true if the passed in xdsclient.ResourceData
-// is equal to that of the receiver.
-func (grd *genericResourceData) Equal(other xdsclient.ResourceData) bool {
-	if other == nil {
-		return false
-	}
-	otherResourceData, ok := other.(*genericResourceData)
-	if !ok {
-		return false
-	}
-	return grd.resourceData.RawEqual(otherResourceData.resourceData)
-}
-
-// Bytes returns the underlying raw bytes of the wrapped resource.
-func (grd *genericResourceData) Bytes() []byte {
-	rawAny := grd.resourceData.Raw()
-	if rawAny == nil {
-		return nil
-	}
-	return rawAny.Value
-}
-
-// genericResourceWatcher wraps xdsresource.ResourceWatcher and implements
-// xdsclient.ResourceWatcher.
-//
-// TODO: #8313 - Delete this once the internal xdsclient usages are updated
-// to use the generic xdsclient.ResourceWatcher interface directly.
-type genericResourceWatcher struct {
-	xdsResourceWatcher ResourceWatcher
-}
-
-// ResourceChanged indicates a new version of the wrapped resource is
-// available.
-func (gw *genericResourceWatcher) ResourceChanged(gData xdsclient.ResourceData, done func()) {
-	if gData == nil {
-		gw.xdsResourceWatcher.ResourceChanged(nil, done)
-		return
-	}
-
-	grd, ok := gData.(*genericResourceData)
-	if !ok {
-		err := fmt.Errorf("genericResourceWatcher received unexpected xdsclient.ResourceData type %T, want *genericResourceData", gData)
-		gw.xdsResourceWatcher.ResourceError(err, done)
-		return
-	}
-	gw.xdsResourceWatcher.ResourceChanged(grd.resourceData, done)
-}
-
-// ResourceError indicates an error occurred while trying to fetch or
-// decode the associated wrapped resource. The previous version of the
-// wrapped resource should be considered invalid.
-func (gw *genericResourceWatcher) ResourceError(err error, done func()) {
-	gw.xdsResourceWatcher.ResourceError(err, done)
-}
-
-// AmbientError indicates an error occurred after a resource has been
-// received that should not modify the use of that wrapped resource but may
-// provide useful information about the state of the XDSClient for debugging
-// purposes. The previous version of the wrapped resource should still be
-// considered valid.
-func (gw *genericResourceWatcher) AmbientError(err error, done func()) {
-	gw.xdsResourceWatcher.AmbientError(err, done)
-}
-
-// GenericResourceWatcher returns a xdsclient.ResourceWatcher that wraps an
-// xdsresource.ResourceWatcher to make it compatible with xdsclient.ResourceWatcher.
-func GenericResourceWatcher(xdsResourceWatcher ResourceWatcher) xdsclient.ResourceWatcher {
-	if xdsResourceWatcher == nil {
-		return nil
-	}
-	return &genericResourceWatcher{xdsResourceWatcher: xdsResourceWatcher}
 }

--- a/xds/csds/csds_e2e_test.go
+++ b/xds/csds/csds_e2e_test.go
@@ -51,6 +51,7 @@ import (
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	v3statuspbgrpc "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
+	clientimpl "google.golang.org/grpc/internal/xds/clients/xdsclient"
 
 	_ "google.golang.org/grpc/internal/xds/httpfilter/router" // Register the router filter
 )
@@ -95,7 +96,7 @@ func (nopRouteConfigWatcher) AmbientError(_ error, onDone func()) {
 
 type nopClusterWatcher struct{}
 
-func (nopClusterWatcher) ResourceChanged(_ *xdsresource.ClusterResourceData, onDone func()) {
+func (nopClusterWatcher) ResourceChanged(_ clientimpl.ResourceData, onDone func()) {
 	onDone()
 }
 func (nopClusterWatcher) ResourceError(_ error, onDone func()) {


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8381

RELEASE NOTES:

xds/internal: Refactored the gRPC xdsclient to eliminate temporary wrappers and embeddings, directly aligning its resource types and watchers with the generic xdsclient interfaces